### PR TITLE
Clarify Contact

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -103,7 +103,7 @@ Available Item types are:
 | Type Name      | Description | Command Types |
 |----------------|-------------|---------------|
 | Color          | Color information (RGB) | OnOff, IncreaseDecrease, Percent, HSB |
-| Contact        | Status of contacts, e.g. door/window contacts | OpenClose |
+| Contact        | Status of contacts, e.g. door/window contacts. Does not accept commands, only status updates. | OpenClosed |
 | DateTime       | Stores date and time | - |
 | Dimmer         | Percentage value for dimmers | OnOff, IncreaseDecrease, Percent |
 | Group          | Item to nest other items / collect them in groups | - |
@@ -113,7 +113,7 @@ Available Item types are:
 | Player         | Allows control of players (e.g. audio players) | PlayPause, NextPrevious, RewindFastforward |
 | Rollershutter  | Roller shutter Item, typically used for blinds | UpDown, StopMove, Percent |
 | String         | Stores texts | String |
-| Switch         | Switch Item, typically used for lights (on/off) | OnOff |
+| Switch         | Switch Item, used for anything that needs to be switched ON and OFF | OnOff |
 
 More details about all of the available Item types and their commands are available under Concepts, see:
 [Item Types Overview]({{base}}/concepts/items.html)


### PR DESCRIPTION
I spent hours trying to find the problem, as I was trying to send a command to a contact. I think it should be mentioned a contact item only accepts status, and the 'CommandType' should be renamed OpenClosed with a D as the status is in fact CLOSED and not CLOSE. Less confusing this way.